### PR TITLE
 Add zig cc compiler for windows

### DIFF
--- a/14_immediate_draw/proc/win/zigcc.sh
+++ b/14_immediate_draw/proc/win/zigcc.sh
@@ -1,0 +1,35 @@
+#!bin/sh
+
+rm -rf bin
+mkdir bin
+cd bin
+
+proj_name=App
+proj_root_dir=$(pwd)/../
+
+flags=(
+	-std=gnu99 -w
+)
+
+# Include directories
+inc=(
+	-I ../../third_party/include/			# Gunslinger includes
+)
+
+# Source files
+src=(
+	../source/main.c
+)
+
+libs=(
+	-lopengl32
+	-lkernel32 
+	-luser32 
+	-lshell32 
+	-lgdi32 
+    -lWinmm
+	-lAdvapi32
+)
+
+# Build
+zig cc -Wall -D__PRFCHWINTRIN_H -O1 ${inc[*]} ${src[*]} ${flags[*]} ${libs[*]} -o ${proj_name}.exe


### PR DESCRIPTION
Dear @MrFrenik,

There are two things to point out, to be able to compile with zig cc on windows 10:

- We need to add the **-D__PRFCHWINTRIN_H** flag, to define **__PRFCHWINTRIN_H** because we get the error: 
```shell
zig\tools\zig-windows-x86_64-0.7.0\lib\zig\include\prfchwintrin.h:50:1: error: conflicting types for '_m_prefetchw'
```
if we don't. Because the *_m_prefetchw* fonction is already defined in *Windows Kits\10\Include\10.0.18362.0\um\winnt.h:3324* (in my case on windows 10).

- If we make a full debug build (so with -O0 flag), the app compiles, but nothing happens. The window shows a white blank screen, and the app crashes right after that (I guess the problem comes when loading the fonts but I didn't dive into it).

I only tested this example with zig cc compiler, which, under the hood is clang (but a small version of it, without llvm heavy stuff).

The best part using zig cc is that we can target other architecture than windows with the *-target* flag (cf https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html)

One of the other benefit of using zig cc is that it caches some build steps. So if we want to build the examples faster when we tweak them, we can simply remove the ```shell rm -rf bin | mkdir bin``` line at the top of this shell script (I keeped it to correspond to the mingw.sh script).